### PR TITLE
Add ECS tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Mina::Infinum
 
 For `mina 0.3.0` please take a look at [v0.3.0 branch](https://github.com/infinum/mina-infinum/tree/v0.3.0)
+
+## ECS
+
+For ECS-related setup, see [this README](lib/mina/infinum/ecs/README.md).
+
 ## Plugins
 
 * [mina](https://github.com/mina-deploy/mina), '> 1.0'

--- a/lib/mina/infinum/ecs.rb
+++ b/lib/mina/infinum/ecs.rb
@@ -2,6 +2,12 @@ require 'mina/default'
 require 'mina/infinum/ecs/rails'
 require 'mina/infinum/ecs/db'
 
+# INFO: hides default Mina tasks when running "mina --tasks"
+Rake::Task['run'].clear_comments
+Rake::Task['ssh'].clear_comments
+Rake::Task['ssh_keyscan_domain'].clear_comments
+Rake::Task['ssh_keyscan_repo'].clear_comments
+
 def squish(command)
   command.gsub(/[[:space:]]+/, ' ').strip
 end

--- a/lib/mina/infinum/ecs.rb
+++ b/lib/mina/infinum/ecs.rb
@@ -1,0 +1,7 @@
+require 'mina/default'
+require 'mina/infinum/ecs/rails'
+require 'mina/infinum/ecs/db'
+
+def squish(command)
+  command.gsub(/[[:space:]]+/, ' ').strip
+end

--- a/lib/mina/infinum/ecs.rb
+++ b/lib/mina/infinum/ecs.rb
@@ -5,3 +5,17 @@ require 'mina/infinum/ecs/db'
 def squish(command)
   command.gsub(/[[:space:]]+/, ' ').strip
 end
+
+def run_cmd(cmd, exec: false)
+  print_command(cmd) if fetch(:verbose)
+
+  if exec
+    Kernel.exec cmd
+  else
+    Kernel.` cmd
+  end
+end
+
+def debug?
+  fetch(:debug, false)
+end

--- a/lib/mina/infinum/ecs/README.md
+++ b/lib/mina/infinum/ecs/README.md
@@ -31,7 +31,7 @@ set :service, 'service_name'
 
 task :staging do
   set :rails_env, 'staging'
-  set :aws_bastion_id, 'i-ec2_instance_id'
+  set :aws_jump_server_id, 'i-ec2_instance_id'
   set :db_host, 'production_db_host'
   # set :db_port, 3306 (default: 5432)
   set :cluster, 'production_cluster_name'
@@ -39,7 +39,7 @@ end
 
 task :production do
   set :rails_env, 'production'
-  set :aws_bastion_id, 'i-ec2_instance_id'
+  set :aws_jump_server_id, 'i-ec2_instance_id'
   set :db_host, 'production_db_host'
   # set :db_port, 3306 (default: 5432)
   set :cluster, 'production_cluster_name'
@@ -64,7 +64,7 @@ To see commands before they run, append `verbose=true`, e.g.: `bundle exec mina 
 $ bundle exec mina staging db:proxy verbose=true
 
   $ aws configure list-profiles
-  $ aws ssm start-session --target aws_bastion_id --document-name AWS-StartPortForwardingSessionToRemoteHost --parameters host="db_host",portNumber="5432",localPortNumber="9999" --profile aws_profile
+  $ aws ssm start-session --target aws_jump_server_id --document-name AWS-StartPortForwardingSessionToRemoteHost --parameters host="db_host",portNumber="5432",localPortNumber="9999" --profile aws_profile
 
 Starting session with SessionId: botocore-session-12345
 Port 9999 opened for sessionId botocore-session-12345.

--- a/lib/mina/infinum/ecs/README.md
+++ b/lib/mina/infinum/ecs/README.md
@@ -1,6 +1,19 @@
 # ECS tasks
 
-Copy the following into `config/deploy.rb` and adjust variables:
+This module contains common tasks for accessing ECS containers and Rails applications on them.
+
+Tasks are split in several namespaces:
+- `aws`: AWS-related commands (profile creation, SSO login)
+- `db`: interaction with DBs (forwarding remote DB port to local machine)
+- `ecs`: interaction with ECS containers (e.g. running commands)
+- `rails`: interaction with Rails apps on ECS containers (e.g. opening the console)
+
+To find available tasks, run `bundle exec mina --tasks`.
+To read detailed task descriptions, run `bundle exec mina --describe/-D`.
+
+## Setup
+
+To get started, copy the following into `config/deploy.rb` and adjust variables:
 
 ```ruby
 require 'mina/infinum/ecs'
@@ -9,13 +22,18 @@ set :aws_profile, 'profile_name'
 set :aws_source_profile, 'source_profile_name'
 set :aws_region, 'region'
 set :aws_role_arn, 'role_arn'
+# set :aws_login_profile, 'login_profile_name' (uses :aws_source_profile by default)
 
 set :service, 'service_name'
+# set :db_local_port, 4242 (default: 9999)
+
+# set :shell, 'zsh' (default: 'bash')
 
 task :staging do
   set :rails_env, 'staging'
   set :aws_bastion_id, 'i-ec2_instance_id'
   set :db_host, 'production_db_host'
+  # set :db_port, 3306 (default: 5432)
   set :cluster, 'production_cluster_name'
 end
 
@@ -23,12 +41,12 @@ task :production do
   set :rails_env, 'production'
   set :aws_bastion_id, 'i-ec2_instance_id'
   set :db_host, 'production_db_host'
+  # set :db_port, 3306 (default: 5432)
   set :cluster, 'production_cluster_name'
 end
 ```
 
-To find available tasks, run `bundle exec mina --tasks`.
-To read detailed task descriptions, run `bundle exec mina --describe/-D`.
+## Debug mode
 
 To see debug output, append `debug=true` to command, e.g.: `bundle exec mina staging db:proxy debug=true`:
 ```
@@ -38,6 +56,8 @@ $ bundle exec mina staging db:proxy debug=true
 2025-05-27 09:32:14,455 - MainThread - awscli.clidriver - DEBUG - Arguments entered to CLI: ['configure', 'list-profiles', '--debug']
 # and so on...
 ```
+
+## Verbose mode
 
 To see commands before they run, append `verbose=true`, e.g.: `bundle exec mina staging db:proxy verbose=true`:
 ```

--- a/lib/mina/infinum/ecs/README.md
+++ b/lib/mina/infinum/ecs/README.md
@@ -27,6 +27,19 @@ task :production do
 end
 ```
 
-To see available tasks, run `bundle exec mina --tasks`.
+To find available tasks, run `bundle exec mina --tasks`.
+To read detailed task descriptions, run `bundle exec mina --describe/-D`.
 
-To see debug output, append `debug=true` to command, e.g.: `bundle exec mina staging db:proxy debug=true`.
+To see debug output of AWS commands, append `debug=true` to command, e.g.: `bundle exec mina staging db:proxy debug=true`.
+
+To see commands before they run, append `verbose=true`, e.g.: `bundle exec mina staging db:proxy verbose=true`:
+```
+$ bundle exec mina staging db:proxy verbose=true
+
+  $ aws configure list-profiles
+  $ aws ssm start-session --target aws_bastion_id --document-name AWS-StartPortForwardingSessionToRemoteHost --parameters host="db_host",portNumber="5432",localPortNumber="9999" --profile aws_profile
+
+Starting session with SessionId: botocore-session-12345
+Port 9999 opened for sessionId botocore-session-12345.
+Waiting for connections...
+```

--- a/lib/mina/infinum/ecs/README.md
+++ b/lib/mina/infinum/ecs/README.md
@@ -1,0 +1,32 @@
+# ECS tasks
+
+Copy the following into `config/deploy.rb` and adjust variables:
+
+```ruby
+require 'mina/infinum/ecs'
+
+set :aws_profile, 'profile_name'
+set :aws_source_profile, 'source_profile_name'
+set :aws_region, 'region'
+set :aws_role_arn, 'role_arn'
+
+set :service, 'service_name'
+
+task :staging do
+  set :rails_env, 'staging'
+  set :aws_bastion_id, 'i-ec2_instance_id'
+  set :db_host, 'production_db_host'
+  set :cluster, 'production_cluster_name'
+end
+
+task :production do
+  set :rails_env, 'production'
+  set :aws_bastion_id, 'i-ec2_instance_id'
+  set :db_host, 'production_db_host'
+  set :cluster, 'production_cluster_name'
+end
+```
+
+To see available tasks, run `bundle exec mina --tasks`.
+
+To see debug output, append `debug=true` to command, e.g.: `bundle exec mina staging db:proxy debug=true`.

--- a/lib/mina/infinum/ecs/README.md
+++ b/lib/mina/infinum/ecs/README.md
@@ -8,7 +8,7 @@ Tasks are split in several namespaces:
 - `ecs`: interaction with ECS containers (e.g. running commands)
 - `rails`: interaction with Rails apps on ECS containers (e.g. opening the console)
 
-To find available tasks, run `bundle exec mina --tasks`.
+To find available tasks, run `bundle exec mina --tasks`.<br />
 To read detailed task descriptions, run `bundle exec mina --describe/-D`.
 
 ## Setup

--- a/lib/mina/infinum/ecs/README.md
+++ b/lib/mina/infinum/ecs/README.md
@@ -30,7 +30,14 @@ end
 To find available tasks, run `bundle exec mina --tasks`.
 To read detailed task descriptions, run `bundle exec mina --describe/-D`.
 
-To see debug output of AWS commands, append `debug=true` to command, e.g.: `bundle exec mina staging db:proxy debug=true`.
+To see debug output, append `debug=true` to command, e.g.: `bundle exec mina staging db:proxy debug=true`:
+```
+$ bundle exec mina staging db:proxy debug=true
+
+2025-05-27 09:32:14,455 - MainThread - awscli.clidriver - DEBUG - CLI version: aws-cli/2.2.6 Python/3.8.8 Darwin/24.5.0 exe/x86_64
+2025-05-27 09:32:14,455 - MainThread - awscli.clidriver - DEBUG - Arguments entered to CLI: ['configure', 'list-profiles', '--debug']
+# and so on...
+```
 
 To see commands before they run, append `verbose=true`, e.g.: `bundle exec mina staging db:proxy verbose=true`:
 ```

--- a/lib/mina/infinum/ecs/aws.rb
+++ b/lib/mina/infinum/ecs/aws.rb
@@ -46,7 +46,7 @@ namespace :aws do
       ensure!(:aws_profile)
 
       unless profile_exists?(fetch(:aws_profile))
-        error! "Please create AWS profile '#{fetch(:aws_profile)}' first (use `aws:profile:create` task)"
+        error! "Please create AWS profile '#{fetch(:aws_profile)}' first (use task aws:profile:create)"
       end
     end
 

--- a/lib/mina/infinum/ecs/aws.rb
+++ b/lib/mina/infinum/ecs/aws.rb
@@ -11,7 +11,15 @@ namespace :aws do
     puts "AWS CLI v2 is intalled. Version: #{version}" if debug?
   end
 
-  desc 'Log in to AWS'
+  desc <<~TXT
+    Log in to AWS
+
+    Retrieves an SSO access token from AWS. Prerequisite for any task
+    which requires authentication (for example, ecs:connect).
+
+    Logs in with profile :aws_login_profile if defined, otherwise uses
+    :aws_source_profile.
+  TXT
   task login: [:ensure_cli_version] do
     ensure!(:aws_source_profile)
 
@@ -38,7 +46,17 @@ namespace :aws do
       end
     end
 
-    desc 'Create AWS profile'
+    desc <<~TXT
+      Create AWS profile
+
+      Creates profile :aws_profile on local machine. Prerequisite for
+      any task which uses AWS resources (for example, ecs:connect).
+
+      The profile is set up with parameters:
+      - source_profile -> :aws_source_profile
+      - region -> :aws_region
+      - role_arn -> :aws_role_arn
+    TXT
     task create: [:ensure_cli_version] do
       ensure!(:aws_profile)
       ensure!(:aws_source_profile)
@@ -54,8 +72,8 @@ namespace :aws do
       else
         puts "Creating profile '#{fetch(:aws_profile)}'..."
         run_cmd "aws configure set source_profile #{fetch(:aws_source_profile)} --profile #{fetch(:aws_profile)} #{'--debug' if debug?}"
-        run_cmd "aws configure set region #{fetch(:aws_source_profile)} --profile #{fetch(:aws_profile)} #{'--debug' if debug?}"
-        run_cmd "aws configure set role_arn #{fetch(:aws_source_profile)} --profile #{fetch(:aws_profile)} #{'--debug' if debug?}"
+        run_cmd "aws configure set region #{fetch(:aws_region)} --profile #{fetch(:aws_profile)} #{'--debug' if debug?}"
+        run_cmd "aws configure set role_arn #{fetch(:aws_role_arn)} --profile #{fetch(:aws_profile)} #{'--debug' if debug?}"
         puts 'Done'
       end
     end

--- a/lib/mina/infinum/ecs/aws.rb
+++ b/lib/mina/infinum/ecs/aws.rb
@@ -28,7 +28,11 @@ namespace :aws do
     run_cmd "aws sso login --profile #{login_profile}", exec: true
   end
 
-  desc 'Open AWS console in the browser'
+  desc <<~TXT
+    Open AWS console in the browser
+
+    The console is opened in region :aws_region.
+  TXT
   task console: ['profile:check'] do
     ensure!(:aws_region)
 

--- a/lib/mina/infinum/ecs/aws.rb
+++ b/lib/mina/infinum/ecs/aws.rb
@@ -1,0 +1,75 @@
+require 'English'
+
+set :debug, false
+
+namespace :aws do
+  task :ensure_cli_version do
+    version = `aws --version #{'--debug' if debug?}`
+
+    error! 'AWS CLI version 2 is required' unless version.start_with?('aws-cli/2')
+
+    puts "AWS CLI v2 is intalled. Version: #{version}" if debug?
+  end
+
+  desc 'Log in to AWS'
+  task login: [:ensure_cli_version] do
+    ensure!(:aws_source_profile)
+
+    login_profile = fetch(:aws_login_profile, fetch(:aws_source_profile))
+
+    Kernel.exec "aws sso login --profile #{login_profile}"
+  end
+
+  desc 'Open AWS console in the browser'
+  task console: ['profile:check'] do
+    ensure!(:aws_region)
+
+    region = fetch(:aws_region)
+
+    Kernel.exec "open https://#{region}.console.aws.amazon.com/console/home?region=#{region}"
+  end
+
+  namespace :profile do
+    task :check do
+      ensure!(:aws_profile)
+
+      unless profile_exists?(fetch(:aws_profile))
+        error! "Please create AWS profile '#{fetch(:aws_profile)}' first (use `aws:profile:create` task)"
+      end
+    end
+
+    desc 'Create AWS profile'
+    task create: [:ensure_cli_version] do
+      ensure!(:aws_profile)
+      ensure!(:aws_source_profile)
+      ensure!(:aws_region)
+      ensure!(:aws_role_arn)
+
+      unless profile_exists?(fetch(:aws_source_profile))
+        error! "Please create AWS source profile first - #{fetch(:aws_source_profile)}"
+      end
+
+      if profile_exists?(fetch(:aws_profile)) && !fetch(:force)
+        puts "Profile '#{fetch(:aws_profile)}' already exists, add 'force=true' to overwrite it"
+      else
+        puts "Creating profile '#{fetch(:aws_profile)}'..."
+        `aws configure set source_profile #{fetch(:aws_source_profile)} --profile #{fetch(:aws_profile)} #{'--debug' if debug?}`
+        `aws configure set region #{fetch(:aws_source_profile)} --profile #{fetch(:aws_profile)} #{'--debug' if debug?}`
+        `aws configure set role_arn #{fetch(:aws_source_profile)} --profile #{fetch(:aws_profile)} #{'--debug' if debug?}`
+        puts 'Done'
+      end
+    end
+  end
+end
+
+def profile_exists?(profile)
+  profiles = `aws configure list-profiles #{'--debug' if debug?}`
+
+  error! 'Cannot list AWS profiles' unless $CHILD_STATUS.success?
+
+  profiles.split("\n").include?(profile)
+end
+
+def debug?
+  fetch(:debug, false)
+end

--- a/lib/mina/infinum/ecs/aws.rb
+++ b/lib/mina/infinum/ecs/aws.rb
@@ -4,7 +4,7 @@ set :debug, false
 
 namespace :aws do
   task :ensure_cli_version do
-    version = `aws --version #{'--debug' if debug?}`
+    version = run_cmd "aws --version #{'--debug' if debug?}"
 
     error! 'AWS CLI version 2 is required' unless version.start_with?('aws-cli/2')
 
@@ -17,7 +17,7 @@ namespace :aws do
 
     login_profile = fetch(:aws_login_profile, fetch(:aws_source_profile))
 
-    Kernel.exec "aws sso login --profile #{login_profile}"
+    run_cmd "aws sso login --profile #{login_profile}", exec: true
   end
 
   desc 'Open AWS console in the browser'
@@ -26,7 +26,7 @@ namespace :aws do
 
     region = fetch(:aws_region)
 
-    Kernel.exec "open https://#{region}.console.aws.amazon.com/console/home?region=#{region}"
+    run_cmd "open https://#{region}.console.aws.amazon.com/console/home?region=#{region}", exec: true
   end
 
   namespace :profile do
@@ -53,9 +53,9 @@ namespace :aws do
         puts "Profile '#{fetch(:aws_profile)}' already exists, add 'force=true' to overwrite it"
       else
         puts "Creating profile '#{fetch(:aws_profile)}'..."
-        `aws configure set source_profile #{fetch(:aws_source_profile)} --profile #{fetch(:aws_profile)} #{'--debug' if debug?}`
-        `aws configure set region #{fetch(:aws_source_profile)} --profile #{fetch(:aws_profile)} #{'--debug' if debug?}`
-        `aws configure set role_arn #{fetch(:aws_source_profile)} --profile #{fetch(:aws_profile)} #{'--debug' if debug?}`
+        run_cmd "aws configure set source_profile #{fetch(:aws_source_profile)} --profile #{fetch(:aws_profile)} #{'--debug' if debug?}"
+        run_cmd "aws configure set region #{fetch(:aws_source_profile)} --profile #{fetch(:aws_profile)} #{'--debug' if debug?}"
+        run_cmd "aws configure set role_arn #{fetch(:aws_source_profile)} --profile #{fetch(:aws_profile)} #{'--debug' if debug?}"
         puts 'Done'
       end
     end
@@ -63,13 +63,9 @@ namespace :aws do
 end
 
 def profile_exists?(profile)
-  profiles = `aws configure list-profiles #{'--debug' if debug?}`
+  profiles = run_cmd "aws configure list-profiles #{'--debug' if debug?}"
 
   error! 'Cannot list AWS profiles' unless $CHILD_STATUS.success?
 
   profiles.split("\n").include?(profile)
-end
-
-def debug?
-  fetch(:debug, false)
 end

--- a/lib/mina/infinum/ecs/db.rb
+++ b/lib/mina/infinum/ecs/db.rb
@@ -1,0 +1,24 @@
+require 'mina/infinum/ecs/aws'
+
+namespace :db do
+  desc 'Forward remote DB port to local port through an SSM session'
+  task proxy: ['aws:profile:check'] do |_, args|
+    ensure!(:aws_bastion_id)
+    ensure!(:db_host)
+
+    profile = fetch(:aws_profile)
+    bastion_id = fetch(:aws_bastion_id)
+    host = fetch(:db_host)
+    remote_port = fetch(:db_port, 5432)
+    local_port = args.to_a.fetch(0) { fetch(:db_tunnel_port, 9999) }
+
+    Kernel.exec squish(<<~CMD)
+      aws ssm start-session
+        --target #{bastion_id}
+        --document-name AWS-StartPortForwardingSessionToRemoteHost
+        --parameters host="#{host}",portNumber="#{remote_port}",localPortNumber="#{local_port}"
+        --profile #{profile}
+        #{'--debug' if debug?}
+    CMD
+  end
+end

--- a/lib/mina/infinum/ecs/db.rb
+++ b/lib/mina/infinum/ecs/db.rb
@@ -12,7 +12,7 @@ namespace :db do
     remote_port = fetch(:db_port, 5432)
     local_port = fetch(:db_tunnel_port, 9999)
 
-    Kernel.exec squish(<<~CMD)
+    run_cmd squish(<<~CMD), exec: true
       aws ssm start-session
         --target #{bastion_id}
         --document-name AWS-StartPortForwardingSessionToRemoteHost

--- a/lib/mina/infinum/ecs/db.rb
+++ b/lib/mina/infinum/ecs/db.rb
@@ -1,7 +1,16 @@
 require 'mina/infinum/ecs/aws'
 
 namespace :db do
-  desc 'Forward remote DB port to local port through an SSM session'
+  desc <<~TXT
+    Forward remote DB port to local port through an SSM session
+
+    Connects to the AWS resource :aws_bastion_id through an SSM session
+    and forwards port :db_port (default: 5432) on host :db_host to local
+    port :db_local_port (default: 9999).
+
+    You can override local port in config/deploy.rb, or inline:
+    $ mina db:proxy db_local_port=4242
+  TXT
   task proxy: ['aws:profile:check'] do
     ensure!(:aws_bastion_id)
     ensure!(:db_host)

--- a/lib/mina/infinum/ecs/db.rb
+++ b/lib/mina/infinum/ecs/db.rb
@@ -4,7 +4,7 @@ namespace :db do
   desc <<~TXT
     Forward remote DB port to local port through an SSM session
 
-    Connects to the AWS resource :aws_bastion_id through an SSM session
+    Connects to the AWS resource :aws_jump_server_id through an SSM session
     and forwards port :db_port (default: 5432) on host :db_host to local
     port :db_local_port (default: 9999). Uses profile :aws_profile.
 
@@ -12,18 +12,18 @@ namespace :db do
     $ mina db:proxy db_local_port=4242
   TXT
   task proxy: ['aws:profile:check'] do
-    ensure!(:aws_bastion_id)
+    ensure!(:aws_jump_server_id)
     ensure!(:db_host)
 
     profile = fetch(:aws_profile)
-    bastion_id = fetch(:aws_bastion_id)
+    jump_server_id = fetch(:aws_jump_server_id)
     host = fetch(:db_host)
     remote_port = fetch(:db_port, 5432)
     local_port = fetch(:db_local_port, 9999)
 
     run_cmd squish(<<~CMD), exec: true
       aws ssm start-session
-        --target #{bastion_id}
+        --target #{jump_server_id}
         --document-name AWS-StartPortForwardingSessionToRemoteHost
         --parameters host="#{host}",portNumber="#{remote_port}",localPortNumber="#{local_port}"
         --profile #{profile}

--- a/lib/mina/infinum/ecs/db.rb
+++ b/lib/mina/infinum/ecs/db.rb
@@ -10,7 +10,7 @@ namespace :db do
     bastion_id = fetch(:aws_bastion_id)
     host = fetch(:db_host)
     remote_port = fetch(:db_port, 5432)
-    local_port = fetch(:db_tunnel_port, 9999)
+    local_port = fetch(:db_local_port, 9999)
 
     run_cmd squish(<<~CMD), exec: true
       aws ssm start-session

--- a/lib/mina/infinum/ecs/db.rb
+++ b/lib/mina/infinum/ecs/db.rb
@@ -6,7 +6,7 @@ namespace :db do
 
     Connects to the AWS resource :aws_bastion_id through an SSM session
     and forwards port :db_port (default: 5432) on host :db_host to local
-    port :db_local_port (default: 9999).
+    port :db_local_port (default: 9999). Uses profile :aws_profile.
 
     You can override local port in config/deploy.rb, or inline:
     $ mina db:proxy db_local_port=4242

--- a/lib/mina/infinum/ecs/db.rb
+++ b/lib/mina/infinum/ecs/db.rb
@@ -2,7 +2,7 @@ require 'mina/infinum/ecs/aws'
 
 namespace :db do
   desc 'Forward remote DB port to local port through an SSM session'
-  task proxy: ['aws:profile:check'] do |_, args|
+  task proxy: ['aws:profile:check'] do
     ensure!(:aws_bastion_id)
     ensure!(:db_host)
 
@@ -10,7 +10,7 @@ namespace :db do
     bastion_id = fetch(:aws_bastion_id)
     host = fetch(:db_host)
     remote_port = fetch(:db_port, 5432)
-    local_port = args.to_a.fetch(0) { fetch(:db_tunnel_port, 9999) }
+    local_port = fetch(:db_tunnel_port, 9999)
 
     Kernel.exec squish(<<~CMD)
       aws ssm start-session

--- a/lib/mina/infinum/ecs/ecs.rb
+++ b/lib/mina/infinum/ecs/ecs.rb
@@ -2,7 +2,15 @@ require 'json'
 require 'mina/infinum/ecs/aws'
 
 namespace :ecs do
-  desc 'Execute a command on ECS container'
+  desc <<~TXT
+    Execute a command on ECS container
+
+    Executes command :command on the running ECS task in cluster :cluster
+    for service :service using profile :aws_profile.
+
+    Command is provided as a rake task argument:
+    $ mina "ecs:exec[container_cmd]"
+  TXT
   task :exec, [:command] => ['aws:profile:check'] do |_, args|
     ensure!(:cluster)
     ensure!(:service)
@@ -18,12 +26,17 @@ namespace :ecs do
         --cluster #{fetch(:cluster)}
         --profile #{fetch(:aws_profile)}
         --interactive
-        #{"--container #{fetch(:container)}" if fetch(:container)}
         #{'--debug' if debug?}
     CMD
   end
 
-  desc 'Connect to the ECS container'
+  desc <<~TXT
+    Connect to the ECS container
+
+    Uses ecs:exec task to start a shell on the container.
+
+    The shell is defined with :shell (default is "bash").
+  TXT
   task :connect do
     invoke 'ecs:exec', fetch(:shell, 'bash')
   end

--- a/lib/mina/infinum/ecs/ecs.rb
+++ b/lib/mina/infinum/ecs/ecs.rb
@@ -11,7 +11,7 @@ namespace :ecs do
 
     task_arn = find_task_arn
 
-    Kernel.exec squish(<<~CMD)
+    run_cmd squish(<<~CMD), exec: true
       aws ecs execute-command
         --task #{task_arn}
         --command \"#{command}\"
@@ -30,7 +30,7 @@ namespace :ecs do
 end
 
 def find_task_arn
-  output = Kernel.` squish(<<~CMD)
+  output = run_cmd squish(<<~CMD)
     aws ecs list-tasks
       --output json
       --cluster #{fetch(:cluster)}

--- a/lib/mina/infinum/ecs/ecs.rb
+++ b/lib/mina/infinum/ecs/ecs.rb
@@ -53,7 +53,7 @@ def find_task_arn
   CMD
 
   unless $CHILD_STATUS.success?
-    error! 'Cannot list ECS tasks, see above error (set --debug flag for more info)'
+    error! "Cannot list ECS tasks... do you need to log in (use task aws:login)? For more info, add debug=true to command"
   end
 
   JSON.parse(output).dig('taskArns', 0) || error!('There are no task definitions')

--- a/lib/mina/infinum/ecs/ecs.rb
+++ b/lib/mina/infinum/ecs/ecs.rb
@@ -1,0 +1,47 @@
+require 'json'
+require 'mina/infinum/ecs/aws'
+
+namespace :ecs do
+  desc 'Execute a command on ECS container'
+  task exec: ['aws:profile:check'] do |_, args|
+    ensure!(:cluster)
+    ensure!(:service)
+
+    command = args.to_a.fetch(0) { error! "You must provide a command as task argument" }
+
+    task_arn = find_task_arn
+
+    Kernel.exec squish(<<~CMD)
+      aws ecs execute-command
+        --task #{task_arn}
+        --command \"#{command}\"
+        --cluster #{fetch(:cluster)}
+        --profile #{fetch(:aws_profile)}
+        --interactive
+        #{"--container #{fetch(:container)}" if fetch(:container)}
+        #{'--debug' if debug?}
+    CMD
+  end
+
+  desc 'Connect to the ECS container'
+  task :connect do
+    invoke 'ecs:exec', fetch(:shell, 'bash')
+  end
+end
+
+def find_task_arn
+  output = Kernel.` squish(<<~CMD)
+    aws ecs list-tasks
+      --output json
+      --cluster #{fetch(:cluster)}
+      --service #{fetch(:service)}
+      --profile #{fetch(:aws_profile)}
+      #{'--debug' if debug?}
+  CMD
+
+  unless $CHILD_STATUS.success?
+    error! 'Cannot list ECS tasks, see above error (set --debug flag for more info)'
+  end
+
+  JSON.parse(output).dig('taskArns', 0) || error!('There are no task definitions')
+end

--- a/lib/mina/infinum/ecs/ecs.rb
+++ b/lib/mina/infinum/ecs/ecs.rb
@@ -3,11 +3,11 @@ require 'mina/infinum/ecs/aws'
 
 namespace :ecs do
   desc 'Execute a command on ECS container'
-  task exec: ['aws:profile:check'] do |_, args|
+  task :exec, [:command] => ['aws:profile:check'] do |_, args|
     ensure!(:cluster)
     ensure!(:service)
 
-    command = args.to_a.fetch(0) { error! "You must provide a command as task argument" }
+    command = args.fetch(:command) { error! 'Command is a required argument' }
 
     task_arn = find_task_arn
 

--- a/lib/mina/infinum/ecs/ecs.rb
+++ b/lib/mina/infinum/ecs/ecs.rb
@@ -5,11 +5,11 @@ namespace :ecs do
   desc <<~TXT
     Execute a command on ECS container
 
-    Executes command :command on the running ECS task in cluster :cluster
-    for service :service using profile :aws_profile.
+    Executes command :command in interactive mode on container in active
+    task on cluster :cluster for service :service. Uses profile :aws_profile.
 
     Command is provided as a rake task argument:
-    $ mina "ecs:exec[container_cmd]"
+    $ mina "ecs:exec[command]"
   TXT
   task :exec, [:command] => ['aws:profile:check'] do |_, args|
     ensure!(:cluster)
@@ -35,7 +35,7 @@ namespace :ecs do
 
     Uses ecs:exec task to start a shell on the container.
 
-    The shell is defined with :shell (default is "bash").
+    The shell is defined with :shell (default: 'bash').
   TXT
   task :connect do
     invoke 'ecs:exec', fetch(:shell, 'bash')

--- a/lib/mina/infinum/ecs/rails.rb
+++ b/lib/mina/infinum/ecs/rails.rb
@@ -2,12 +2,14 @@ require 'mina/infinum/ecs/ecs'
 
 desc 'Execute a rails command'
 desc <<~TXT
-  Execute a rails command
+  Execute a Rails command
 
-  Uses ecs:exec task to execute rails command on the container.
+  Uses ecs:exec task to execute a Rails command on the container.
 
   Command is provided as a rake task argument:
   $ mina "rails[command]"
+  and is executed on the container as:
+  $ bundle exec rails [command]
 TXT
 task :rails, [:command] do |_, args|
   ensure!(:rails_env)
@@ -18,12 +20,20 @@ task :rails, [:command] do |_, args|
 end
 
 namespace :rails do
-  desc 'Open rails console'
+  desc <<~TXT
+    Open rails console
+
+    Runs "bundle exec rails console" on the ECS container.
+  TXT
   task :console do
     invoke 'rails', 'console'
   end
 
-  desc 'Tail application log'
+  desc <<~TXT
+    Tail application log
+
+    Log is tailed from `log` folder for environment :rails_env.
+  TXT
   task :log do
     ensure!(:rails_env)
 

--- a/lib/mina/infinum/ecs/rails.rb
+++ b/lib/mina/infinum/ecs/rails.rb
@@ -1,0 +1,24 @@
+require 'mina/infinum/ecs/ecs'
+
+desc 'Execute a rails command'
+task :rails do |_, args|
+  ensure!(:rails_env)
+
+  command = args.to_a.fetch(0) { error! "Provide a command as argument" }
+
+  invoke 'ecs:exec', "bundle exec rails #{command}"
+end
+
+namespace :rails do
+  desc 'Open rails console'
+  task :console do
+    invoke 'rails', 'console'
+  end
+
+  desc 'Tail application log'
+  task :log do
+    ensure!(:rails_env)
+
+    invoke 'ecs:exec', "tail -f log/#{fetch(:rails_env)}.log"
+  end
+end

--- a/lib/mina/infinum/ecs/rails.rb
+++ b/lib/mina/infinum/ecs/rails.rb
@@ -1,6 +1,14 @@
 require 'mina/infinum/ecs/ecs'
 
 desc 'Execute a rails command'
+desc <<~TXT
+  Execute a rails command
+
+  Uses ecs:exec task to execute rails command on the container.
+
+  Command is provided as a rake task argument:
+  $ mina "rails[command]"
+TXT
 task :rails, [:command] do |_, args|
   ensure!(:rails_env)
 

--- a/lib/mina/infinum/ecs/rails.rb
+++ b/lib/mina/infinum/ecs/rails.rb
@@ -1,10 +1,10 @@
 require 'mina/infinum/ecs/ecs'
 
 desc 'Execute a rails command'
-task :rails do |_, args|
+task :rails, [:command] do |_, args|
   ensure!(:rails_env)
 
-  command = args.to_a.fetch(0) { error! "Provide a command as argument" }
+  command = args.fetch(:command) { error! 'Command is a required argument' }
 
   invoke 'ecs:exec', "bundle exec rails #{command}"
 end


### PR DESCRIPTION
The following tasks are added:
```
mina aws:console         # Open AWS console in the browser
mina aws:login           # Log in to AWS
mina aws:profile:create  # Create AWS profile
mina db:proxy            # Forward remote DB port to local port through an SSM session
mina ecs:connect         # Connect to the ECS container
mina ecs:exec[command]   # Execute a command on ECS container
mina rails[command]      # Execute a rails command
mina rails:console       # Open rails console
mina rails:log           # Tail application log
```