### PR TITLE
Add aliases for aws:login and rails:console tasks

### DIFF
--- a/lib/mina/infinum/ecs/aws.rb
+++ b/lib/mina/infinum/ecs/aws.rb
@@ -91,3 +91,6 @@ def profile_exists?(profile)
 
   profiles.split("\n").include?(profile)
 end
+
+desc 'Alias for aws:login'
+task :login => 'aws:login'

--- a/lib/mina/infinum/ecs/rails.rb
+++ b/lib/mina/infinum/ecs/rails.rb
@@ -40,3 +40,6 @@ namespace :rails do
     invoke 'ecs:exec', "tail -f log/#{fetch(:rails_env)}.log"
   end
 end
+
+desc 'Alias for rails:console'
+task :console => 'rails:console'


### PR DESCRIPTION
`aws:login` is aliased as `login`.
`rails:console` is aliased as `console` (like Mina has [by default](https://github.com/mina-deploy/mina/blob/dc9deda3d678eb4702bc020b1ddd5a7d3456834b/tasks/mina/rails.rb#L17-L22)).

These are common enough that I think `mina login` and `mina staging console` should be enough to open a console on a remote environment.