### PR TITLE
Add `logs` and `logs:tail` AWS tasks

### DIFF
--- a/lib/mina/infinum/ecs.rb
+++ b/lib/mina/infinum/ecs.rb
@@ -1,5 +1,6 @@
 require 'mina/default'
 require 'mina/infinum/ecs/rails'
+require 'mina/infinum/ecs/logs'
 require 'mina/infinum/ecs/db'
 require 'mina/infinum/ecs/params'
 

--- a/lib/mina/infinum/ecs/logs.rb
+++ b/lib/mina/infinum/ecs/logs.rb
@@ -11,15 +11,18 @@ desc <<~TXT
   parseable by `Time.parse` (e.g. ISO8601 timestamps). :since is required,
   :until is optional (if omitted, value will be current time).
 
-  Some examples:
+  Examples:
   # all logs since 26.9.2025. 14:00 (local time zone) until now
   $ mina logs since="2025-09-26 14:00"
 
   # all logs on 26.9.2025. between 14:00 and 15:00
   $ mina logs since="2025-09-26 14:00" until="2025-09-26 15:00"
 
-  # all logs between 14:00 and 15:00 today
+  # all logs between 14:00 and 15:00 today in local time zone
   $ mina logs since="14:00" until="15:00"
+
+  # all logs between 14:00 and 15:00 today in UTC
+  $ mina logs since="14:00Z" until="15:00Z"
 
   # UTC time zone
   $ mina logs since="2025-09-26T14:00Z"

--- a/lib/mina/infinum/ecs/logs.rb
+++ b/lib/mina/infinum/ecs/logs.rb
@@ -11,6 +11,8 @@ desc <<~TXT
   parseable by `Time.parse` (e.g. ISO8601 timestamps). :since is required,
   :until is optional (if omitted, value will be current time).
 
+  If date is ommitted in either value, the current date is assumed.
+
   Examples:
   # logs since 26.9.2025. 14:00 in local time zone
   $ mina logs since="2025-09-26 14:00"
@@ -67,6 +69,8 @@ namespace :logs do
     Before new logs are tailed, recent logs are first printed. You can control
     from what time recent logs are printed with :since. The value can be absolute
     time parseable by `Time.parse`, or relative time.
+
+    If date is ommitted in absolute time, the current date is assumed.
 
     Examples:
     # tail logs since 26.9.2025. 14:00 in local time zone

--- a/lib/mina/infinum/ecs/logs.rb
+++ b/lib/mina/infinum/ecs/logs.rb
@@ -1,4 +1,3 @@
-require 'rainbow'
 require 'time'
 require 'mina/infinum/ecs/aws'
 
@@ -53,7 +52,7 @@ task logs: ['aws:profile:check'] do
   if logs.any?
     logs.each do |log|
       time = Time.at(0, log.fetch('timestamp'), :millisecond)
-      puts "#{Rainbow(time.utc.iso8601).green} #{log.fetch('message')}"
+      puts "#{green_text(time.utc.iso8601)} #{log.fetch('message')}"
     end
   else
     puts 'There are no logs'
@@ -106,4 +105,8 @@ namespace :logs do
         #{"--since #{since_time}" if since_time}
     CMD
   end
+end
+
+def green_text(text)
+  "\e[32m#{text}\e[0m"
 end

--- a/lib/mina/infinum/ecs/logs.rb
+++ b/lib/mina/infinum/ecs/logs.rb
@@ -90,9 +90,9 @@ namespace :logs do
   task tail: ['aws:profile:check'] do
     ensure!(:log_group)
 
-    since_time = fetch(:since).strip
+    since_time = fetch(:since)&.strip
 
-    if !since_time.empty? && !since_time.match?(/\A\d+\w\z/)
+    if since_time && !since_time.empty? && !since_time.match?(/\A\d+\w\z/)
       since_time = Time.parse(since_time).iso8601
     end
 

--- a/lib/mina/infinum/ecs/logs.rb
+++ b/lib/mina/infinum/ecs/logs.rb
@@ -1,0 +1,82 @@
+require 'rainbow'
+require 'time'
+require 'mina/infinum/ecs/aws'
+
+desc <<~TXT
+  Print logs from CloudWatch
+
+  Logs are printed from :log_group, which is a CloudWatch log group name.
+
+  Logs are fetched in range :start to :end (both inclusive). Both values must be
+  parseable by `Time.parse` (e.g. ISO8601 timestamps). :start is required,
+  :end is optional (if omitted, value will be current time).
+
+  Some examples:
+  # all logs from 26.9.2025. 14:00 (local time zone) until now
+  $ mina logs start="2025-09-26 14:00"
+
+  $ mina logs start="2025-09-26 14:00" end="2025-09-26 15:00"
+
+  # UTC time zone
+  $ mina logs start="2025-09-26T14:00Z"
+TXT
+task logs: ['aws:profile:check'] do
+  ensure!(:log_group)
+  ensure!(:start)
+
+  start_time = Time.parse(fetch(:start))
+  end_time = fetch(:end) ? Time.parse(fetch(:end)) : Time.now
+
+  puts "Printing logs from #{fetch(:log_group)} in range [#{start_time.iso8601},#{end_time.iso8601}]"
+  raw_logs = run_cmd squish(<<~CMD)
+    aws logs filter-log-events
+      --log-group-name #{fetch(:log_group)}
+      --profile #{fetch(:aws_profile)}
+      --start-time #{start_time.strftime('%s%L')}
+      --end-time #{end_time.strftime('%s%L')}
+      --output json
+      --query "events[].{timestamp: timestamp, message: message}"
+  CMD
+
+  next if raw_logs.empty? # response can be empty due to auth issues, user will see error in terminal
+
+  logs = JSON.parse(raw_logs)
+  if logs.any?
+    logs.each do |log|
+      time = Time.at(0, log.fetch('timestamp'), :millisecond)
+      puts "#{Rainbow(time.utc.iso8601).green} #{log.fetch('message')}"
+    end
+  else
+    puts 'There are no logs'
+  end
+end
+
+namespace :logs do
+  desc <<~TXT
+    Tail logs from CloudWatch
+
+    Logs are tailed from :log_group, which is a CloudWatch log group name.
+
+    Before new logs are tailed, recent logs are first printed. You can control
+    from what time recent logs are printed with :start. The value can be an
+    ISO 8601 timestamp or a relative time. For example:
+    $ mina logs:tail start="2025-09-26T12:00:00"
+    or
+    $ mina logs:tail start="5m"
+
+    For more info on accepted :start values, see --since options
+    https://docs.aws.amazon.com/cli/latest/reference/logs/tail.html#options
+  TXT
+  task tail: ['aws:profile:check'] do
+    ensure!(:log_group)
+
+    puts "Tailing logs from #{fetch(:log_group)}"
+    run_cmd squish(<<~CMD), exec: true
+      aws logs tail #{fetch(:log_group)}
+        --profile #{fetch(:aws_profile)}
+        --follow
+        --format short
+        #{"--since #{fetch(:start)}" if fetch(:start)}
+    CMD
+  end
+end

--- a/lib/mina/infinum/ecs/logs.rb
+++ b/lib/mina/infinum/ecs/logs.rb
@@ -7,33 +7,37 @@ desc <<~TXT
 
   Logs are printed from :log_group, which is a CloudWatch log group name.
 
-  Logs are fetched in range :start to :end (both inclusive). Both values must be
-  parseable by `Time.parse` (e.g. ISO8601 timestamps). :start is required,
-  :end is optional (if omitted, value will be current time).
+  Logs are fetched in range :since to :until (both inclusive). Both values must be
+  parseable by `Time.parse` (e.g. ISO8601 timestamps). :since is required,
+  :until is optional (if omitted, value will be current time).
 
   Some examples:
-  # all logs from 26.9.2025. 14:00 (local time zone) until now
-  $ mina logs start="2025-09-26 14:00"
+  # all logs since 26.9.2025. 14:00 (local time zone) until now
+  $ mina logs since="2025-09-26 14:00"
 
-  $ mina logs start="2025-09-26 14:00" end="2025-09-26 15:00"
+  # all logs on 26.9.2025. between 14:00 and 15:00
+  $ mina logs since="2025-09-26 14:00" until="2025-09-26 15:00"
+
+  # all logs between 14:00 and 15:00 today
+  $ mina logs since="14:00" until="15:00"
 
   # UTC time zone
-  $ mina logs start="2025-09-26T14:00Z"
+  $ mina logs since="2025-09-26T14:00Z"
 TXT
 task logs: ['aws:profile:check'] do
   ensure!(:log_group)
-  ensure!(:start)
+  ensure!(:since)
 
-  start_time = Time.parse(fetch(:start))
-  end_time = fetch(:end) ? Time.parse(fetch(:end)) : Time.now
+  since_time = Time.parse(fetch(:since))
+  until_time = fetch(:until) ? Time.parse(fetch(:until)) : Time.now
 
-  puts "Printing logs from #{fetch(:log_group)} in range [#{start_time.iso8601},#{end_time.iso8601}]"
+  puts "Printing logs from #{fetch(:log_group)} in range [#{since_time.iso8601},#{until_time.iso8601}]"
   raw_logs = run_cmd squish(<<~CMD)
     aws logs filter-log-events
       --log-group-name #{fetch(:log_group)}
       --profile #{fetch(:aws_profile)}
-      --start-time #{start_time.strftime('%s%L')}
-      --end-time #{end_time.strftime('%s%L')}
+      --start-time #{since_time.strftime('%s%L')}
+      --end-time #{until_time.strftime('%s%L')}
       --output json
       --query "events[].{timestamp: timestamp, message: message}"
   CMD
@@ -58,13 +62,13 @@ namespace :logs do
     Logs are tailed from :log_group, which is a CloudWatch log group name.
 
     Before new logs are tailed, recent logs are first printed. You can control
-    from what time recent logs are printed with :start. The value can be an
+    from what time recent logs are printed with :since. The value can be an
     ISO 8601 timestamp or a relative time. For example:
-    $ mina logs:tail start="2025-09-26T12:00:00"
+    $ mina logs:tail since="2025-09-26T12:00:00"
     or
-    $ mina logs:tail start="5m"
+    $ mina logs:tail since="5m"
 
-    For more info on accepted :start values, see --since options
+    For more info on accepted :since values, see --since options
     https://docs.aws.amazon.com/cli/latest/reference/logs/tail.html#options
   TXT
   task tail: ['aws:profile:check'] do
@@ -76,7 +80,7 @@ namespace :logs do
         --profile #{fetch(:aws_profile)}
         --follow
         --format short
-        #{"--since #{fetch(:start)}" if fetch(:start)}
+        #{"--since #{fetch(:since)}" if fetch(:since)}
     CMD
   end
 end

--- a/mina-infinum.gemspec
+++ b/mina-infinum.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mina-dox'
   spec.add_dependency 'mina-secrets'
   spec.add_dependency 'mina-whenever'
+  spec.add_dependency 'rainbow'
 end

--- a/mina-infinum.gemspec
+++ b/mina-infinum.gemspec
@@ -34,5 +34,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mina-dox'
   spec.add_dependency 'mina-secrets'
   spec.add_dependency 'mina-whenever'
-  spec.add_dependency 'rainbow'
 end


### PR DESCRIPTION
Adds tasks to print logs in a given time range (`logs`) and tail logs (`logs:tail`) from CloudWatch.

To use these tasks, the user must set the `:log_group` variable, which represents the CloudWatch log group from which to fetch logs.

`logs` task accepts `since` (required) and `until` (optional, default is current time) arguments, which can be passed on the CLI, e.g.:
```
mina logs since="10:00" until="10:05"
```

`logs:tail` task accepts `since` argument, which controls from what time to tail logs. Logs are tailed continuously until the user stops the command (e.g. sends a SIGINT signal with Ctrl+C).

Both tasks accept `since` and `until` arguments in various formats (relative time, absolute local time, UTC time, time without date, etc.). Please refer to the documentation for possible values. 