### PR TITLE
Add `skip_profile` flag to call AWS CLI commands without a `--profile` flag

### DIFF
--- a/lib/mina/infinum/ecs/README.md
+++ b/lib/mina/infinum/ecs/README.md
@@ -70,3 +70,7 @@ Starting session with SessionId: botocore-session-12345
 Port 9999 opened for sessionId botocore-session-12345.
 Waiting for connections...
 ```
+
+## Skip profile
+
+To execute AWS CLI commands without the `--profile` flag, append `skip_profile=true` to your commands, e.g.: `bundle exec mina staging params:pull skip_profile=true`.

--- a/lib/mina/infinum/ecs/aws.rb
+++ b/lib/mina/infinum/ecs/aws.rb
@@ -43,6 +43,8 @@ namespace :aws do
 
   namespace :profile do
     task :check do
+      next if fetch(:skip_profile)
+
       ensure!(:aws_profile)
 
       unless profile_exists?(fetch(:aws_profile))
@@ -90,6 +92,10 @@ def profile_exists?(profile)
   error! 'Cannot list AWS profiles' unless $CHILD_STATUS.success?
 
   profiles.split("\n").include?(profile)
+end
+
+def aws_cli_profile_flag
+  fetch(:aws_profile) && !fetch(:skip_profile) ? "--profile #{fetch(:aws_profile)}" : ''
 end
 
 desc 'Alias for aws:login'

--- a/lib/mina/infinum/ecs/db.rb
+++ b/lib/mina/infinum/ecs/db.rb
@@ -15,7 +15,6 @@ namespace :db do
     ensure!(:aws_jump_server_id)
     ensure!(:db_host)
 
-    profile = fetch(:aws_profile)
     jump_server_id = fetch(:aws_jump_server_id)
     host = fetch(:db_host)
     remote_port = fetch(:db_port, 5432)
@@ -26,7 +25,7 @@ namespace :db do
         --target #{jump_server_id}
         --document-name AWS-StartPortForwardingSessionToRemoteHost
         --parameters host="#{host}",portNumber="#{remote_port}",localPortNumber="#{local_port}"
-        --profile #{profile}
+        #{aws_cli_profile_flag}
         #{'--debug' if debug?}
     CMD
   end

--- a/lib/mina/infinum/ecs/ecs.rb
+++ b/lib/mina/infinum/ecs/ecs.rb
@@ -24,7 +24,7 @@ namespace :ecs do
         --task #{task_arn}
         --command \"#{command}\"
         --cluster #{fetch(:cluster)}
-        --profile #{fetch(:aws_profile)}
+        #{aws_cli_profile_flag}
         --interactive
         #{'--debug' if debug?}
     CMD
@@ -48,7 +48,7 @@ def find_task_arn
       --output json
       --cluster #{fetch(:cluster)}
       --service #{fetch(:service)}
-      --profile #{fetch(:aws_profile)}
+      #{aws_cli_profile_flag}
       #{'--debug' if debug?}
   CMD
 

--- a/lib/mina/infinum/ecs/logs.rb
+++ b/lib/mina/infinum/ecs/logs.rb
@@ -39,7 +39,7 @@ task logs: ['aws:profile:check'] do
   raw_logs = run_cmd squish(<<~CMD)
     aws logs filter-log-events
       --log-group-name #{fetch(:log_group)}
-      --profile #{fetch(:aws_profile)}
+      #{aws_cli_profile_flag}
       --start-time #{since_time.strftime('%s%L')}
       --end-time #{until_time.strftime('%s%L')}
       --output json
@@ -99,7 +99,7 @@ namespace :logs do
     puts "Tailing logs from #{fetch(:log_group)}"
     run_cmd squish(<<~CMD), exec: true
       aws logs tail #{fetch(:log_group)}
-        --profile #{fetch(:aws_profile)}
+        #{aws_cli_profile_flag}
         --follow
         --format short
         #{"--since #{since_time}" if since_time}

--- a/lib/mina/infinum/ecs/params.rb
+++ b/lib/mina/infinum/ecs/params.rb
@@ -61,7 +61,7 @@ def get_params_from_aws
       --path #{params_path}
       --with-decryption
       --recursive
-      --profile #{fetch(:aws_profile)}
+      #{aws_cli_profile_flag}
       #{'--debug' if debug?}
   CMD
 


### PR DESCRIPTION
### Aim

We need to support a custom workflow which:
- sets up the app on an environment (staging)
- runs specs to generate the openapi spec documentation
- run yarn redocly to generate the HTML API documentation
- pull params from staging from AWS ParamStore (for next step)
- use shrine to upload the HTML API documentation to an S3 bucket

Our workflow uses aws_role_to_assume, and we don't need to pull params with a profile, since we don't have a profile (we can't login, since it's the CI/CD). In order to use roles instead of the profile, one needs to simply remove the profile flag from the aws command.

### Solution

Make `aws_profile` optional.