### PR TITLE
Add path param to params:pull task

### DIFF
--- a/lib/mina/infinum/ecs/params.rb
+++ b/lib/mina/infinum/ecs/params.rb
@@ -15,7 +15,11 @@ namespace :params do
   end
 
   desc <<~TXT
-    Save AWS Param Store params to .env file
+    Save AWS Param Store params to a file
+
+    Params are by default stored to .env file, you can override
+    the location with :path. For example:
+    $ mina params:pull path=.env.local
 
     See params:read documentation for details on how params
     are fetched.

--- a/lib/mina/infinum/ecs/params.rb
+++ b/lib/mina/infinum/ecs/params.rb
@@ -21,7 +21,9 @@ namespace :params do
     are fetched.
   TXT
   task pull: ['aws:profile:check'] do
-    env_file_path = File.join(Dir.pwd, '.env')
+    path = fetch(:path) || '.env'
+
+    env_file_path = File.join(Dir.pwd, path)
 
     File.write(env_file_path, get_params.map(&:as_env).join("\n"))
   end


### PR DESCRIPTION
### Aim

We need to have a way to pull the params from AWS ParamStore into another file. The default `.env` file is the lowest priority, and we'd like to save the params in a higher priority file (source [dotenv](https://github.com/bkeepers/dotenv?tab=readme-ov-file#customizing-rails))

### Solution

Add optional `path` variable to params:pull task with the default being '.env'.