### PR TITLE
Add upcase argument to params:pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Enhancements
+- Add `upcase` argument to `params:pull` task which causes environment variable name to be upper-cased
+
+
 ## [v2.4.0](https://github.com/infinum/mina-infinum/tree/v-2.4.0) (2025-10-14)
 [Full Changelog](https://github.com/infinum/mina-infinum/compare/v2.3.0...v2.4.0)
 

--- a/lib/mina/infinum/ecs/params.rb
+++ b/lib/mina/infinum/ecs/params.rb
@@ -21,15 +21,19 @@ namespace :params do
     the location with :path. For example:
     $ mina params:pull path=.env.local
 
+    Use upcase=true to transform variable names to upper-case:
+    $ mina params:pull upcase=true
+
     See params:read documentation for details on how params
     are fetched.
   TXT
   task pull: ['aws:profile:check'] do
     path = fetch(:path) || '.env'
+    upcase = fetch(:upcase) == 'true'
 
     env_file_path = File.join(Dir.pwd, path)
 
-    File.write(env_file_path, get_params.map(&:as_env).join("\n"))
+    File.write(env_file_path, get_params.map { |p| p.as_env(upcase:) }.join("\n"))
   end
 end
 
@@ -39,8 +43,10 @@ Param = Data.define(:name, :value) do
     name.split('/').last
   end
 
-  def as_env
-    "#{variable_name}=#{value}"
+  def as_env(upcase: false)
+    key = upcase ? variable_name.upcase : variable_name
+
+    "#{key}=#{value}"
   end
 end
 

--- a/lib/mina/infinum/ecs/params.rb
+++ b/lib/mina/infinum/ecs/params.rb
@@ -29,7 +29,7 @@ namespace :params do
   TXT
   task pull: ['aws:profile:check'] do
     path = fetch(:path) || '.env'
-    upcase = fetch(:upcase) == 'true'
+    upcase = fetch(:upcase, 'true').to_s == 'true'
 
     env_file_path = File.join(Dir.pwd, path)
 


### PR DESCRIPTION
#### Aim & Solution

Add `upcase` argument to `params:pull` task which causes environment variable name to be upper-cased before it being saved to the local env file.